### PR TITLE
disable auto truncate line in split windows

### DIFF
--- a/inits/01-display.el
+++ b/inits/01-display.el
@@ -82,7 +82,7 @@
                   initial-frame-alist)))
 (set-frame-parameter nil 'alpha '70)
 (setq default-frame-alist initial-frame-alist)
-
+(setq truncate-partial-width-windows nil) ;split-windowもで文字の折り返しを有効にする
 
 ;;;モード
 ;;ファイルとの関連付け


### PR DESCRIPTION
## Why
分割windowなどウィンドウの幅が50列より狭くなったとき、Emacsは自動的に行を切り詰めに切り替える。
https://ayatakesi.github.io/emacs/25.1/Split-Window.html#Split-Window

基本的にディスプレイは十分な広さがある前提なのでこの設定は不要。

## What
自動的な行切り詰めを無効にして、折り返し表示を有効にする。