### PR TITLE
refactor: clean up emacs leaf configurations

### DIFF
--- a/init.el
+++ b/init.el
@@ -1,3 +1,6 @@
+; (setq warning-minimum-level :debug)
+; (setq debug-on-error t)
+
 ;;; インストールパスの設定.emacsのバージョンごとのディレクトリに作成する
 ;; el-get経由はv24.4.1/el-get, elpa経由はv24.4.1/elpaに作成する
 (let ((versioned-dir (locate-user-emacs-file (format "v%s" emacs-version))))
@@ -56,7 +59,7 @@
   :ensure t
   :config
   (setq-default init-loader-show-log-after-init t
-		        init-loader-byte-compile t)
+		        init-loader-byte-compile nil) ;; temporary t -> nil
+  (init-loader-load (locate-user-emacs-file "inits"))
   )
 
-(init-loader-load (locate-user-emacs-file "inits"))

--- a/inits/00-init.el
+++ b/inits/00-init.el
@@ -4,7 +4,9 @@
 
 ;;check if target font exist
 (defun font-exists-p (font)
-  (if (null (x-list-fonts  font)) nil t))
+  (if (display-graphic-p)
+      (if (null (x-list-fonts  font)) nil t)
+      nil))
 
 ;;;フォント
 (if (font-exists-p "HackGen")

--- a/inits/11-programming.el
+++ b/inits/11-programming.el
@@ -24,7 +24,7 @@
 ;; lsp-mode
 (leaf lsp-mode
   :ensure t
-  :bind ("C-c h" . lsp-describe-thing-at-point)
+  :bind (("C-c h" . lsp-describe-thing-at-point))
   :custom (lsp-rust-server 'rust-analyzer))
 
 
@@ -93,8 +93,8 @@
 (leaf go-mode
   :ensure t
   :bind
-  ("M-." . godef-jump)  ; 関数定義にジャンプ
-  ("M-*" . pop-tag-mark)  ; ジャンプ元に戻る
+  (("M-." . godef-jump)  ; 関数定義にジャンプ
+   ("M-*" . pop-tag-mark))  ; ジャンプ元に戻る
   :hook
   (before-save-hook . gofmt-before-save)
   (go-mode-hook . lsp-deferred)

--- a/inits/11-yasnippet.el
+++ b/inits/11-yasnippet.el
@@ -1,14 +1,15 @@
 ;;; yasnippet
-(leaf yasnippet
-  :ensure t
-  :config
-  (setq yas-snippet-dirs (append yas-snippet-dirs
-                                 (list
-                                  (locate-user-emacs-file "etc/yasnippets")
-                                  (locate-user-emacs-file "etc/yasnippet-snippets/snippets"))))
-  (custom-set-variables '(yas-trigger-key "TAB"))
-  (define-key yas-minor-mode-map (kbd "C-x i i") 'yas-insert-snippet) ;; 既存スニペットを挿入する
-  (define-key yas-minor-mode-map (kbd "C-x i n") 'yas-new-snippet) ;; 新規スニペットを作成するバッファを用意する
-  (define-key yas-minor-mode-map (kbd "C-x i v") 'yas-visit-snippet-file) ;; 既存スニペットを閲覧・編集する
-  (yas-global-mode 1)
-  )
+;; (leaf yasnippet
+;;   :ensure t
+;;   :config
+;;   (setq yas-snippet-dirs (append yas-snippet-dirs
+;;                                  (list
+;;                                   (locate-user-emacs-file "etc/yasnippets")
+;;                                   (locate-user-emacs-file "etc/yasnippet-snippets/snippets"))))
+;;   (custom-set-variables '(yas-trigger-key "TAB"))
+;;   (define-key yas-minor-mode-map (kbd "C-x i i") 'yas-insert-snippet) ;; 既存スニペットを挿入する
+;;   (define-key yas-minor-mode-map (kbd "C-x i n") 'yas-new-snippet) ;; 新規スニペットを作成するバッファを用意する
+;;   (define-key yas-minor-mode-map (kbd "C-x i v") 'yas-visit-snippet-file) ;; 既存スニペットを閲覧・編集する
+;;   (yas-global-mode 1)
+;;   )
+

--- a/inits/12-skk.el
+++ b/inits/12-skk.el
@@ -5,8 +5,8 @@
 (leaf ddskk
   :ensure t
   :bind
-  ("C-x C-j" . skk-mode)
-  ("C-x j" . skk-mode)
+  (("C-x C-j" . skk-mode)
+   ("C-x j" . skk-mode))
   :preface
   (defun get-all-files-in-directory (directory)
     "Get a list of all files in DIRECTORY."
@@ -14,9 +14,8 @@
       (directory-files-recursively directory "SKK-JISYO\\.[a-z]+" nil t)))
   :config
   (setq skk-extra-jisyo-file-list (get-all-files-in-directory "~/.emacs.d/etc/skk/")) ;;追加辞書
-  :custom
-  (default-input-method . "japanese-skk")
-  (skk-kutouten-type . 'jp) ;句読点には「、。」を利用する (デフォルト挙動だが明記する)
-  (skk-large-jisho . "~/.emacs.d/etc/skk/SKK-JISYO.L") ;Large辞書パス
-  (skk-jisyo . "~/.emacs.d/cache/skk/.skk-jisyo") ;個人用辞書パス
+  (setq default-input-method "japanese-skk")
+  (setq skk-kutouten-type 'jp) ;句読点には「、。」を利用する (デフォルト挙動だが明記する)
+  (setq skk-large-jisho "~/.emacs.d/etc/skk/SKK-JISYO.L") ;Large辞書パス
+  (setq skk-jisyo "~/.emacs.d/cache/skk/.skk-jisyo") ;個人用辞書パス
   )

--- a/inits/30-org-howm.el
+++ b/inits/30-org-howm.el
@@ -2,9 +2,9 @@
 (leaf howm
   :ensure t
   :bind
-  ("C-c , ," . howm-menu)
+  (("C-c , ," . howm-menu))
   :custom
-  (howm-directory . "~/Dropbox/documents/howm") ;howmディレクトリ
+  ((howm-directory . "~/Dropbox/documents/howm") ;howmディレクトリ
   (howm-file-name-format . "%Y/%m/%Y-%m-%d-%H%M%S.howm")
   (howm-menu-file . "~/Dropbox/documents/howm/0000-00-00-000000.txt") ;デフォルト値のままだが指定しておく
   (howm-keyword-file . "~/Dropbox/documents/howm/.howm-keys") ;キーワードリスト
@@ -18,7 +18,7 @@
   (howm-menu-schedule-days-before . 21) ;メニューの予定表の表示範囲
   (howm-menu-schedule-days . 7) ;スケジュールを表示する日数
   (howm-view-summary-persistent . nil) ;RET でファイルを開く際, 一覧バッファを消す.C-u RET なら残る.
-  (howm-todo-menu-types . "[-+~!]") ;完了済みToDoは非表示
+  (howm-todo-menu-types . "[-+~!]")) ;完了済みToDoは非表示
 )
 
 ;; 内容が 0 ならファイルごと削除する
@@ -45,5 +45,9 @@
   :custom
   ; orgファイルを開いたときは第2レベルまで開いた状態にする
   ; https://orgmode.org/manual/Initial-visibility.html
-  (org-startup-folded . 'show2levels)
+  ((org-startup-folded . 'show2levels))
   )
+
+(leaf org-pomodoro
+  :ensure t
+)


### PR DESCRIPTION
## Why
複数環境（GUI/CUI）での起動や設定の見通しを改善するため、leaf 設定の記法統一とパッケージ構成の整理を行う。

## What
- leaf の `:bind`/`:custom` を括弧で囲む記法に統一（lsp-mode, go-mode, ddskk, howm, org）
- ddskk の `:custom` 設定を `:config` 内の `setq` に移行
- org-pomodoro パッケージを追加
- yasnippet の設定を無効化（コメントアウト）
- 非GUI(端末)環境では `font-exists-p` が `x-list-fonts` を呼ばず `nil` を返すよう修正
- init-loader の byte-compile を一時的に無効化し、`init-loader-load` を leaf の `:config` 内へ移動